### PR TITLE
refactor: explicitly ignoring test file names

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -32,7 +32,7 @@ extract_issue_summary <- function(txt) {
 }
 
 #' Extract Tests section from Github issue
-#' @importFrom purrr flatten_chr map_df
+#' @importFrom purrr flatten_chr map_df map_chr
 #' @importFrom tibble tibble
 #' @param txt The raw text scraped from the body of the Github issue
 extract_issue_tests <- function(txt) {
@@ -40,21 +40,15 @@ extract_issue_tests <- function(txt) {
   ts <- strsplit(sp[2], "[\n\r]+") %>% flatten_chr %>% rm_blank
   story <- trimws(gsub("^ *[\r\n]+ *", "", sp[1]))
 
-  file_start <- which(grepl("test-.*\\.R$", ts))
-  test_start <- file_start+1
-  test_end <- c((file_start - 1)[-1],length(ts))
+  # get bulleted list entries of test file names and test names
+  file_names_bullets <- which(grepl("test-.*\\.R$", ts))
+  test_bullets <- which(grepl("(-|*) [A-Za-z0-9]+", ts))
 
-  if (length(file_start) == 0) {
-    character()
-  }
+  # filter to only test names (files names are no longer used in mrgvalidate >= 1.0.0)
+  test_bullets <- setdiff(test_bullets, file_names_bullets)
 
-  labs <- rm_h(ts[file_start])
-  .lab <- basename(labs)
-  map(seq_along(file_start), function(i) {
-    se <- seq(test_start[i],test_end[i])
-    rm_s(rm_h(ts[se]))
-  }) %>%
-    unlist()
+  # clean test names and return
+  map_chr(test_bullets, ~{rm_s(rm_h(ts[.x]))})
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,7 +42,7 @@ extract_issue_tests <- function(txt) {
 
   # get bulleted list entries of test file names and test names
   file_names_bullets <- which(grepl("test-.*\\.R$", ts))
-  test_bullets <- which(grepl("(-|*) [A-Za-z0-9]+", ts))
+  test_bullets <- which(grepl("(-|\\*) [A-Za-z0-9]+", ts))
 
   # filter to only test names (files names are no longer used in mrgvalidate >= 1.0.0)
   test_bullets <- setdiff(test_bullets, file_names_bullets)

--- a/tests/testthat/test-parse-github-issues.R
+++ b/tests/testthat/test-parse-github-issues.R
@@ -14,10 +14,6 @@ test_that("parse_github_issues() pulls from Github", {
   # check that TestIds are all character vectors except the last (empty) one
   expect_true(inherits(spec[["TestIds"]], "list"))
   expect_equal(
-    purrr::map_lgl(spec[["TestIds"]], ~!is.null(.x)),
-    c(TRUE,  TRUE,  TRUE,  TRUE,  TRUE, FALSE)
-  )
-  expect_equal(
     purrr::map_lgl(spec[["TestIds"]], ~length(.x) > 1),
     c(TRUE,  TRUE,  TRUE,  TRUE,  TRUE, FALSE)
   )

--- a/tests/testthat/test-parse-github-issues.R
+++ b/tests/testthat/test-parse-github-issues.R
@@ -1,16 +1,3 @@
-test_that("get_issues() pulls from Github", {
-  skip_if_over_rate_limit_github()
-
-  release_issues <- get_issues(org = ORG, repo = REPO, mile = MILESTONE, domain = DOMAIN)
-  expect_equal(nrow(release_issues), STORIES_DF_ROWS_GHP)
-
-  # check a few things that likely won't change if we update some stories
-  expect_true(all(stringr::str_detect(release_issues$body, stringr::regex("Summary.+Tests", dotall = TRUE))))
-  expect_true(all(stringr::str_detect(release_issues$milestone, MILESTONE)))
-  expect_true(all(stringr::str_detect(release_issues$resource_path, REPO)))
-
-})
-
 test_that("parse_github_issues() pulls from Github", {
   skip_if_over_rate_limit_github()
   spec <- parse_github_issues(org = ORG, repo = REPO, mile = MILESTONE, domain = DOMAIN)
@@ -34,5 +21,18 @@ test_that("parse_github_issues() pulls from Github", {
     purrr::map_lgl(spec[["TestIds"]], ~length(.x) > 1),
     c(TRUE,  TRUE,  TRUE,  TRUE,  TRUE, FALSE)
   )
+
+})
+
+test_that("get_issues() pulls from Github", {
+  skip_if_over_rate_limit_github()
+
+  release_issues <- get_issues(org = ORG, repo = REPO, mile = MILESTONE, domain = DOMAIN)
+  expect_equal(nrow(release_issues), STORIES_DF_ROWS_GHP)
+
+  # check a few things that likely won't change if we update some stories
+  expect_true(all(stringr::str_detect(release_issues$body, stringr::regex("Summary.+Tests", dotall = TRUE))))
+  expect_true(all(stringr::str_detect(release_issues$milestone, MILESTONE)))
+  expect_true(all(stringr::str_detect(release_issues$resource_path, REPO)))
 
 })


### PR DESCRIPTION
In `parse_github_issues()` we used to ask for the test names to be nested under the test _file_ names. We no longer care about the test file names so this change just ignores them (if present).

I changed two issues in `mrgvalidatetestreference` to test for this:

* https://github.com/metrumresearchgroup/mrgvalidatetestreference/issues/5 I removed the file name and moved test names to top level
* https://github.com/metrumresearchgroup/mrgvalidatetestreference/issues/4 I changed to `*` instead of `-` to make sure that both will parse.
