### PR TITLE
feat: validate-tests: add option to set ID as test name

### DIFF
--- a/R/validate-tests.R
+++ b/R/validate-tests.R
@@ -37,6 +37,12 @@
 #'   working directory.
 #' @param extra_test_dirs Character vector of paths (relative to package root
 #'   dir) to directories that contain additional tests to run
+#' @param set_id_to_name Whether to copy the `TestName` column over to the
+#'   `TestId` column when writing the output CSV. This exists to support legacy
+#'   issues and tests that don't use IDs. Starting with v1.0, mrgvalidate relies
+#'   on test IDs and, as a temporary compatibility kludge, will auto-generate
+#'   them if the `TestId` and `TestName` columns match. New tests and issues
+#'   should use test IDs.
 #' @export
 validate_tests <- function(
   org,
@@ -46,7 +52,9 @@ validate_tests <- function(
   out_file = NULL,
   root_dir = tempdir(),
   output_dir = getwd(),
-  extra_test_dirs = NULL
+  extra_test_dirs = NULL,
+  set_id_to_name = FALSE
+
 ) {
 
   message(glue("Pulling repo {domain}/{org}/{repo}..."))
@@ -76,6 +84,10 @@ validate_tests <- function(
     })
 
     test_df <- bind_rows(test_df, extra_df)
+  }
+
+  if (isTRUE(set_id_to_name)) {
+    test_df$TestId <- test_df$TestName
   }
 
   if (sum(test_df$failed) > 0) {

--- a/man/validate_tests.Rd
+++ b/man/validate_tests.Rd
@@ -12,7 +12,8 @@ validate_tests(
   out_file = NULL,
   root_dir = tempdir(),
   output_dir = getwd(),
-  extra_test_dirs = NULL
+  extra_test_dirs = NULL,
+  set_id_to_name = FALSE
 )
 }
 \arguments{
@@ -37,6 +38,13 @@ working directory.}
 
 \item{extra_test_dirs}{Character vector of paths (relative to package root
 dir) to directories that contain additional tests to run}
+
+\item{set_id_to_name}{Whether to copy the \code{TestName} column over to the
+\code{TestId} column when writing the output CSV. This exists to support legacy
+issues and tests that don't use IDs. Starting with v1.0, mrgvalidate relies
+on test IDs and, as a temporary compatibility kludge, will auto-generate
+them if the \code{TestId} and \code{TestName} columns match. New tests and issues
+should use test IDs.}
 }
 \value{
 Invisibly returns tibble of formatted test output. Note that this

--- a/tests/testthat/test-validate-tests.R
+++ b/tests/testthat/test-validate-tests.R
@@ -48,13 +48,16 @@ test_that("validate_tests writes output files", {
     domain = VALID_DOMAINS,
     out_file = out_file,
     root_dir = pkg_dir,
-    output_dir = output_dir
+    output_dir = output_dir,
+    set_id_to_name = TRUE
   )
 
   test_df <- readr::read_csv(file.path(output_dir, paste0(out_file, ".csv")), col_types = "ciic")
   expect_equal(nrow(test_df), TEST_DF_ROWS)
   expect_equal(ncol(test_df), TEST_DF_COLS)
   expect_equal(sum(test_df$failed), 0)
+  # set_id_to_name was honored.
+  expect_equal(test_df$TestName, test_df$TestId)
 
   test_info <- jsonlite::fromJSON(file.path(output_dir, paste0(out_file, ".json")))
   expect_equal(names(test_info), c("date", "executor", "info"))


### PR DESCRIPTION
The new mrgvalidate input links tests between the specs and tests by
test ID, but packages that used the old mrgvalidate won't have test
IDs in the issues or test names.

For legacy support, let the validate_tests() caller specify that the
test ID column should be populated from the test names.  On the spec
side, test ID (e.g., from GitHub issues) also needs to be the name.

And mrgvalidate requires the ability to handle this (e.g.,
auto-assigning IDs) so that the output doesn't have ID and NAME info
repeated.

Note: I'm piggybacking on an existing test.  A dedicated one would be
better, but these validate_tests() tests are pretty slow (a bit under
4 minutes for me locally).

---

companion pr in mrgvalidate: metrumresearchgroup/mrgvalidate#56