### PR TITLE
Release/0.0.1

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,4 +5,5 @@
 ^.Rprofile$
 ^LICENSE\.md$
 ^docs/
-pkgr.yml
+^pkgr.yml$
+^_pkgdown.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ all_tests.csv
 *.md
 *.docx
 !NEWS.md
+docs/
 
 renv/*

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ inst/doc
 all_tests.csv
 *.md
 *.docx
+!NEWS.md
 
 renv/*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,11 @@ Authors@R:
     person(given = "Seth",
            family = "Green",
            role = c("aut"),
-           email = "seth127@gmail.com"),
+           email = "sethg@metrumrg.com"),
+    person(given = "Kyle",
+           family = "Meyer",
+           role = c("aut"),
+           email = "kylem@metrumrg.com"),
     person(given = "Kyle T",
            family = "Baron",
            role = c("aut"),
@@ -53,5 +57,5 @@ Suggests:
     forcats,
     cli,
     httpuv,
-    mrgvalidate (>= 0.1.2.9000)
+    mrgvalidate (>= 1.0.0)
 Roxygen: list(markdown = TRUE)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,11 +2,9 @@
 
 export("%>%")
 export(get_issues)
-export(get_risk)
 export(get_sys_info)
 export(parse_github_issues)
 export(parse_testthat_list_reporter)
-export(pull_tagged_repo)
 export(read_spec_gsheets)
 export(validate_tests)
 importFrom(dplyr,bind_rows)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,10 @@
+# mrgvalprep 0.0.1
+
+First release! This release moved some functionality that used to be in `mrgvalidate 0.1.2` into its own package. Much of the old code has been heavily refactored, and new functionality has been added as well.
+
+## Current capabilities
+
+* Pull an R package Github repo at a specific tag and run its test suite, then format the output for `mrgvalidate` (`validate_tests()`)
+* Parses output from `testthat::ListReporter` (`parse_testthat_list_reporter()`)
+* Pulls Stories and Requirements from Googlesheets (`read_spec_gsheets()`)
+* Pulls Stories and Requirements from Github issues and milestones (`parse_github_issues()`)

--- a/R/parse-github-issues.R
+++ b/R/parse-github-issues.R
@@ -63,7 +63,7 @@ get_issues <- function(org, repo, mile, domain = VALID_DOMAINS) {
 #' @importFrom dplyr filter select mutate
 #' @importFrom ghpm api_url
 #' @importFrom rlang .data
-#' @export
+#' @keywords internal
 get_risk <- function(org, repo, domain = VALID_DOMAINS) {
   domain <- match.arg(domain)
   if (domain == "github.com") {

--- a/R/validate-tests.R
+++ b/R/validate-tests.R
@@ -121,7 +121,7 @@ validate_tests <- function(
 #' @param domain Domain where repo lives. Either "github.com" or "ghe.metrumrg.com", defaulting to "github.com"
 #' @param dest_dir File path for directory to clone repo into. Defaults to [tempdir()]
 #' @param overwrite Boolean indicating whether to overwrite `file.path(dest_dir, repo)` if something already exists there. TRUE by default.
-#' @export
+#' @keywords internal
 pull_tagged_repo <- function(
   org,
   repo,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,22 @@
+url: https://metrumresearchgroup.github.io/mrgvalprep
+
+title: mrgvalprep
+template:
+  params:
+    bootswatch: flatly
+navbar:
+  type: inverse
+  right:
+  - icon: fa-github fa-lg
+    href: https://github.com/metrumresearchgroup/mrgvalprep
+reference:
+- title: Format test outputs
+  contents:
+  - validate_tests
+  - get_sys_info
+  - parse_testthat_list_reporter
+- title: Format stories and requirements
+  contents:
+  - read_spec_gsheets
+  - parse_github_issues
+  - get_issues

--- a/man/get_risk.Rd
+++ b/man/get_risk.Rd
@@ -16,3 +16,4 @@ get_risk(org, repo, domain = VALID_DOMAINS)
 \description{
 Get risk field for each issue
 }
+\keyword{internal}

--- a/man/pull_tagged_repo.Rd
+++ b/man/pull_tagged_repo.Rd
@@ -29,3 +29,4 @@ pull_tagged_repo(
 \description{
 Clones the specified repo at the specified tag to disk
 }
+\keyword{internal}

--- a/man/read_spec_gsheets.Rd
+++ b/man/read_spec_gsheets.Rd
@@ -27,18 +27,18 @@ Read requirements and stories from Google Sheets.
 
 The stories sheet passed to \code{ss_stories} must have the following columns:
 \itemize{
-\item StoryId (character scalar)
-\item StoryName (character scalar)
-\item StoryDescription (character scalar)
-\item ProductRisk (character scalar)
-\item RequirementIds (character vector)
+\item \code{StoryId} (character scalar)
+\item \code{StoryName} (character scalar)
+\item \code{StoryDescription} (character scalar)
+\item \code{ProductRisk} (character scalar)
+\item \code{RequirementIds} (character vector)
 }
 
 The requirements sheet passed to \code{ss_req} must have the following columns:
 \itemize{
-\item RequirementId (character scalar)
-\item RequirementDescription (character scalar)
-\item TestIds (character vector)
+\item \code{RequirementId} (character scalar)
+\item \code{RequirementDescription} (character scalar)
+\item \code{TestIds} (character vector)
 }
 }
 
@@ -46,11 +46,11 @@ The requirements sheet passed to \code{ss_req} must have the following columns:
 
 Don't pass anything to \code{ss_req}. The stories sheet passed to \code{ss_stories} must have the following columns:
 \itemize{
-\item StoryId (character scalar)
-\item StoryName (character scalar)
-\item StoryDescription (character scalar)
-\item ProductRisk (character scalar)
-\item TestIds (character vector)
+\item \code{StoryId} (character scalar)
+\item \code{StoryName} (character scalar)
+\item \code{StoryDescription} (character scalar)
+\item \code{ProductRisk} (character scalar)
+\item \code{TestIds} (character vector)
 }
 
 (Note: these are the same columns as Option 1, but replacing \code{RequirementIds} with \code{TestIds})

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -5,10 +5,12 @@ Descriptions:
 Packages:
   - devtools
   - renv
+  - pkgdown
 
 Repos:
   - CRAN: https://cran.rstudio.com
   - ghpm: https://s3.amazonaws.com/mpn.metworx.dev/releases/ghpm/0.5.1
+  - mrgvalidate: https://s3.amazonaws.com/mpn.metworx.dev/releases/mrgvalidate/1.0.0
 
 Lockfile:
   Type: renv
@@ -16,4 +18,6 @@ Lockfile:
 Customizations:
   Packages:
     - ghpm:
+        Type: source
+    - mrgvalidate:
         Type: source

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,3 +1,5 @@
+library(stringr)
+
 ###########################
 # constants for test input
 ###########################
@@ -41,6 +43,9 @@ STORIES_DF_ROWS_GHE <- 5 # this shouldn't ever change because the GHE repo is st
 SPECS_DF_ROWS_GS <- 6
 SPECS_DF_COLS_GS <- 7
 
+VAL_FILE <- "validation-testing.md"
+REQ_FILE <- "requirements-specification.md"
+MAT_FILE <- "traceability-matrix.md"
 
 #######
 # helper functions
@@ -51,23 +56,23 @@ SPECS_DF_COLS_GS <- 7
 #' @param set_id_to_name Same as in [validate_tests()]
 check_docs <- function(spec, docs_output_dir, set_id_to_name = FALSE) {
   # check that files exist
-  expect_true(fs::file_exists(file.path(docs_output_dir, paste0(tools::file_path_sans_ext(mrgvalidate::REQ_FILE), ".docx"))))
-  expect_true(fs::file_exists(file.path(docs_output_dir, paste0(tools::file_path_sans_ext(mrgvalidate::VAL_FILE), ".docx"))))
-  expect_true(fs::file_exists(file.path(docs_output_dir, paste0(tools::file_path_sans_ext(mrgvalidate::MAT_FILE), ".docx"))))
-  expect_true(fs::file_exists(file.path(docs_output_dir, mrgvalidate::REQ_FILE)))
-  expect_true(fs::file_exists(file.path(docs_output_dir, mrgvalidate::VAL_FILE)))
-  expect_true(fs::file_exists(file.path(docs_output_dir, mrgvalidate::MAT_FILE)))
+  expect_true(fs::file_exists(file.path(docs_output_dir, paste0(tools::file_path_sans_ext(REQ_FILE), ".docx"))))
+  expect_true(fs::file_exists(file.path(docs_output_dir, paste0(tools::file_path_sans_ext(VAL_FILE), ".docx"))))
+  expect_true(fs::file_exists(file.path(docs_output_dir, paste0(tools::file_path_sans_ext(MAT_FILE), ".docx"))))
+  expect_true(fs::file_exists(file.path(docs_output_dir, REQ_FILE)))
+  expect_true(fs::file_exists(file.path(docs_output_dir, VAL_FILE)))
+  expect_true(fs::file_exists(file.path(docs_output_dir, MAT_FILE)))
 
   # check for files content
-  req_text <- readr::read_file(file.path(docs_output_dir, mrgvalidate::REQ_FILE))
-  expect_true(any(stringr::str_detect(req_text, spec$StoryId)))
-  expect_true(any(stringr::str_detect(req_text, unlist(spec$TestIds))))
-  if ("RequirementId" %in% names(spec)) expect_true(any(stringr::str_detect(req_text, spec$RequirementId)))
+  req_text <- readr::read_file(file.path(docs_output_dir, REQ_FILE))
+  expect_true(any(str_detect(req_text, spec$StoryId)))
+  expect_true(any(str_detect(req_text, unlist(spec$TestIds))))
+  if ("RequirementId" %in% names(spec)) expect_true(any(str_detect(req_text, spec$RequirementId)))
 
-  val_text <- readr::read_file(file.path(docs_output_dir, mrgvalidate::VAL_FILE))
-  expect_true(any(stringr::str_detect(val_text, unlist(spec$TestIds))))
+  val_text <- readr::read_file(file.path(docs_output_dir, VAL_FILE))
+  expect_true(any(str_detect(val_text, unlist(spec$TestIds))))
 
-  mat_text <- readr::read_file(file.path(docs_output_dir, mrgvalidate::MAT_FILE))
-  expect_true(any(!!stringr::str_detect(mat_text, fixed(stringr::str_extract(str_trim(spec$StoryDescription), "^.+")))))
-  if (isFALSE(set_id_to_name)) expect_true(any(stringr::str_detect(mat_text, unlist(spec$TestIds))))
+  mat_text <- readr::read_file(file.path(docs_output_dir, MAT_FILE))
+  expect_true(any(!!str_detect(mat_text, fixed(str_extract(str_trim(spec$StoryDescription), "^.+")))))
+  if (isFALSE(set_id_to_name)) expect_true(any(str_detect(mat_text, unlist(spec$TestIds))))
 }

--- a/tests/testthat/test-end-to-end.R
+++ b/tests/testthat/test-end-to-end.R
@@ -1,6 +1,6 @@
 # Intended as a mini end-to-end test
 
-skip_if_not_installed("mrgvalidate", minimum_version = "0.1.2.9000")
+skip_if_not_installed("mrgvalidate", minimum_version = "1.0.0")
 
 test_that("Googlesheets end-to-end works", {
   skip_if_over_rate_limit_google()


### PR DESCRIPTION
# mrgvalprep 0.0.1

First release! This release moved some functionality that used to be in `mrgvalidate 0.1.2` into its own package. Much of the old code has been heavily refactored, and new functionality has been added as well.

## Current capabilities

* Pull an R package Github repo at a specific tag and run its test suite, then format the output for `mrgvalidate` (`validate_tests()`)
* Parses output from `testthat::ListReporter` (`parse_testthat_list_reporter()`)
* Pulls Stories and Requirements from Googlesheets (`read_spec_gsheets()`)
* Pulls Stories and Requirements from Github issues and milestones (`parse_github_issues()`)
