### PR TITLE
strip trailing colon when rolling up IDs

### DIFF
--- a/R/parse-test-output.R
+++ b/R/parse-test-output.R
@@ -4,7 +4,9 @@
 #' @param roll_up_ids If `FALSE`, the default, will leave duplicated Test ID's
 #'   as is. If `TRUE`, will roll up any duplicated (non-NA) ID's so that they
 #'   are unique and the passed/failed count reflects the total sums for a tests
-#'   with a given ID.
+#'   with a given ID. The test names for a set of rolled up ID's must share a
+#'   common prefix, which will be used as the new test name. Any trailing
+#'   spaces, slashes, or underscores will be removed from the extracted prefix.
 #' @return A tibble formatted according to `mrgvalidate::input_formats`
 #' @seealso `mrgvalidate::input_formats`, `mrgvalidate::create_validation_docs()`
 #' @importFrom purrr map_chr map_lgl map_dfr
@@ -50,7 +52,10 @@ parse_testthat_list_reporter <- function(result, roll_up_ids = FALSE) {
 #'
 #' * All tests and subtests with the same Test Id will be rolled up to a single
 #' row in the output tibble. The `passed,failed` counts will reflect the number
-#' of tests/subtests that were rolled up this way.
+#' of tests/subtests that were rolled up this way. The test names for a set of
+#' rolled up ID's must share a common prefix, which will be used as the new test
+#' name. Any trailing spaces, slashes, or underscores will be removed from the
+#' extracted prefix.
 #'
 #' * Any test with _more than one Test Id_ will have only the first Test Id
 #' extracted. Any subsequent Test Id's for that test will be ignored. Generally,

--- a/R/parse-test-output.R
+++ b/R/parse-test-output.R
@@ -6,7 +6,8 @@
 #'   are unique and the passed/failed count reflects the total sums for a tests
 #'   with a given ID. The test names for a set of rolled up ID's must share a
 #'   common prefix, which will be used as the new test name. Any trailing
-#'   spaces, slashes, or underscores will be removed from the extracted prefix.
+#'   spaces, slashes, colons, or underscores will be removed from the extracted
+#'   prefix.
 #' @return A tibble formatted according to `mrgvalidate::input_formats`
 #' @seealso `mrgvalidate::input_formats`, `mrgvalidate::create_validation_docs()`
 #' @importFrom purrr map_chr map_lgl map_dfr
@@ -54,8 +55,8 @@ parse_testthat_list_reporter <- function(result, roll_up_ids = FALSE) {
 #' row in the output tibble. The `passed,failed` counts will reflect the number
 #' of tests/subtests that were rolled up this way. The test names for a set of
 #' rolled up ID's must share a common prefix, which will be used as the new test
-#' name. Any trailing spaces, slashes, or underscores will be removed from the
-#' extracted prefix.
+#' name. Any trailing spaces, slashes, colons, or underscores will be removed
+#' from the extracted prefix.
 #'
 #' * Any test with _more than one Test Id_ will have only the first Test Id
 #' extracted. Any subsequent Test Id's for that test will be ignored. Generally,
@@ -160,7 +161,7 @@ leading_lcs <- function(x) {
 
   if (lcs == "") rlang::abort(paste("No leading overlap in\n", paste(x, collapse = "\n ")))
 
-  return (str_replace(lcs, "[\\/_ ]*$", ""))
+  return (str_replace(lcs, "[:\\/_ ]*$", ""))
 }
 
 #' Roll up so test ID's are unique and passed/failed sums up counts

--- a/man/parse_golang_test_json.Rd
+++ b/man/parse_golang_test_json.Rd
@@ -26,7 +26,10 @@ Parses output of \verb{go test --json} into a tibble for \code{mrgvalidate} to c
 \item Any tests \emph{without} Test Id's (correctly formatted \emph{in brackets}) will be thrown out.
 \item All tests and subtests with the same Test Id will be rolled up to a single
 row in the output tibble. The \verb{passed,failed} counts will reflect the number
-of tests/subtests that were rolled up this way.
+of tests/subtests that were rolled up this way. The test names for a set of
+rolled up ID's must share a common prefix, which will be used as the new test
+name. Any trailing spaces, slashes, or underscores will be removed from the
+extracted prefix.
 \item Any test with \emph{more than one Test Id} will have only the first Test Id
 extracted. Any subsequent Test Id's for that test will be ignored. Generally,
 the first Id will be the \emph{least} specific, since subsequent Id's will likely

--- a/man/parse_golang_test_json.Rd
+++ b/man/parse_golang_test_json.Rd
@@ -28,8 +28,8 @@ Parses output of \verb{go test --json} into a tibble for \code{mrgvalidate} to c
 row in the output tibble. The \verb{passed,failed} counts will reflect the number
 of tests/subtests that were rolled up this way. The test names for a set of
 rolled up ID's must share a common prefix, which will be used as the new test
-name. Any trailing spaces, slashes, or underscores will be removed from the
-extracted prefix.
+name. Any trailing spaces, slashes, colons, or underscores will be removed
+from the extracted prefix.
 \item Any test with \emph{more than one Test Id} will have only the first Test Id
 extracted. Any subsequent Test Id's for that test will be ignored. Generally,
 the first Id will be the \emph{least} specific, since subsequent Id's will likely

--- a/man/parse_testthat_list_reporter.Rd
+++ b/man/parse_testthat_list_reporter.Rd
@@ -12,7 +12,9 @@ parse_testthat_list_reporter(result, roll_up_ids = FALSE)
 \item{roll_up_ids}{If \code{FALSE}, the default, will leave duplicated Test ID's
 as is. If \code{TRUE}, will roll up any duplicated (non-NA) ID's so that they
 are unique and the passed/failed count reflects the total sums for a tests
-with a given ID.}
+with a given ID. The test names for a set of rolled up ID's must share a
+common prefix, which will be used as the new test name. Any trailing
+spaces, slashes, or underscores will be removed from the extracted prefix.}
 }
 \value{
 A tibble formatted according to \code{mrgvalidate::input_formats}

--- a/man/parse_testthat_list_reporter.Rd
+++ b/man/parse_testthat_list_reporter.Rd
@@ -14,7 +14,8 @@ as is. If \code{TRUE}, will roll up any duplicated (non-NA) ID's so that they
 are unique and the passed/failed count reflects the total sums for a tests
 with a given ID. The test names for a set of rolled up ID's must share a
 common prefix, which will be used as the new test name. Any trailing
-spaces, slashes, or underscores will be removed from the extracted prefix.}
+spaces, slashes, colons, or underscores will be removed from the extracted
+prefix.}
 }
 \value{
 A tibble formatted according to \code{mrgvalidate::input_formats}

--- a/tests/testthat/test-parse-test-output.R
+++ b/tests/testthat/test-parse-test-output.R
@@ -37,6 +37,23 @@ test_that("parse_testthat_list_reporter() optionally rolls up ID's", {
   )
 })
 
+test_that("trailing colon is stripped when rolling up IDs", {
+  df <- tibble::tribble(
+    ~TestName, ~passed, ~failed, ~TestId,
+    "t1", 2, 0, "FOO-BAR-001",
+    "t2", 1, 0, "FOO-BAR-002",
+    "t3: first case", 1, 0, "FOO-BAR-003",
+    "t3: second case", 3, 0, "FOO-BAR-003")
+
+  expect_equal(
+    roll_up_test_ids(df),
+    tibble::tribble(
+      ~TestName, ~passed, ~failed, ~TestId,
+    "t1", 2, 0, "FOO-BAR-001",
+    "t2", 1, 0, "FOO-BAR-002",
+    "t3", 4, 0, "FOO-BAR-003"))
+})
+
 test_that("parse_golang_test_json() happy path", {
   test_res_file <- system.file("test-refs", "test-parse-test-output-go-test-1.json", package = "mrgvalprep")
   test_ref_file <- system.file("test-refs", "test-parse-test-output-go-test-1-parsed.csv", package = "mrgvalprep")


### PR DESCRIPTION
This PR is a follow up to the discussion at <https://github.com/metrumresearchgroup/bbr/pull/430#discussion_r745814437>.

Test descriptions following the pattern `{test name}: {case} [ID]` are already used in bbr and seem like a natural way to handle subcase descriptions.  Add the colon to the set of characters stripped from the rolled up prefix so that the final name is `{test name}`.
