### PR TITLE
move googlesheets4 to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,12 +47,12 @@ Imports:
     testthat,
     tibble,
     tidyr,
-    withr (>= 2.3.0),
-    googlesheets4
+    withr (>= 2.3.0)
 Suggests:
     checkmate,
     digest,
     ghpm (>= 0.5.1),
+    googlesheets4,
     yaml,
     forcats,
     cli,

--- a/R/read-spec-gsheet.R
+++ b/R/read-spec-gsheet.R
@@ -37,6 +37,9 @@ read_spec_gsheets <- function
   ss_stories, ss_req = NULL,
   sheet_stories = NULL, sheet_req = NULL
 ) {
+  if (!requireNamespace("googlesheets4", quietly = TRUE)) {
+    rlang::abort("Need to install googlesheets4 to use read_spec_gsheets()")
+  }
   res <- if (is.null(ss_req)) {
     read_stories_only_gsheet(ss = ss_stories, sheet = sheet_stories)
   } else {


### PR DESCRIPTION
After #23 we will begin to encourage users to keep stories/requirements in the repo with the code (and use `read_spec_yaml()`) instead of externally in a Googlesheet. Because of this, `googlesheets4` should no longer be required.