### PR TITLE
pkgdown: include read_spec_yaml in index

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -8,6 +8,7 @@
 #' @importFrom dplyr rename mutate_at
 #' @importFrom rlang .data
 #' @param test_path File path to file containing test results
+#' @keywords internal
 read_test_df <- function(test_path = ALL_TESTS) {
   tst <- read_csv(test_path, col_types = cols())
   tst <- rename(tst,test_name = .data$tests, test_file = .data$file, number=.data$nb)
@@ -24,6 +25,7 @@ read_test_df <- function(test_path = ALL_TESTS) {
 #' @importFrom purrr flatten_chr map_df
 #' @importFrom tibble tibble
 #' @param txt The raw text scraped from the body of the Github issue
+#' @keywords internal
 extract_issue_summary <- function(txt) {
   sp <- sp_sections(txt)
   ts <- strsplit(sp[2], "[\n\r]+") %>% flatten_chr %>% rm_blank
@@ -35,6 +37,7 @@ extract_issue_summary <- function(txt) {
 #' @importFrom purrr flatten_chr map_df map_chr
 #' @importFrom tibble tibble
 #' @param txt The raw text scraped from the body of the Github issue
+#' @keywords internal
 extract_issue_tests <- function(txt) {
   sp <- sp_sections(txt)
   ts <- strsplit(sp[2], "[\n\r]+") %>% flatten_chr %>% rm_blank
@@ -59,19 +62,23 @@ extract_issue_tests <- function(txt) {
 
 #' remove leading hyphen
 #' @param x input to clean
+#' @keywords internal
 rm_h <- function(x) trimws(gsub("^ *- *", "",x))
 
 #' remove leading star/bullet
 #' @param x input to clean
+#' @keywords internal
 rm_s <- function(x) trimws(gsub("^ *\\* *", "",x))
 
 #' drop blanks
 #' @param x input to clean
+#' @keywords internal
 rm_blank <- function(x) x[!grepl("^\\s*$",x)]
 
 #' split body by Test and Summary
 #' @param x input to clean
 #' @importFrom purrr flatten_chr
+#' @keywords internal
 sp_sections <- function(x) {
   x <- strsplit(x,"(\\# *Test\\w*|\\# *Summ\\w*)") %>% flatten_chr
   x <- rm_blank(x)

--- a/R/validate-tests.R
+++ b/R/validate-tests.R
@@ -208,6 +208,7 @@ run_tests <- function(pkg, test_path = "tests/testthat", root_dir = tempdir()) {
 #' Specifically, this code came mostly from testthat:::test_package_dir and testthat:::test_pkg_env and some from test_check itself.
 #' @param package the package name
 #' @param test_path path to folder with tests in it
+#' @keywords internal
 setup_package_env <- function(package, test_path) {
 
   if (!utils::file_test("-d", test_path)) {

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -19,5 +19,6 @@ reference:
 - title: Format stories and requirements
   contents:
   - read_spec_gsheets
+  - read_spec_yaml
   - parse_github_issues
   - get_issues

--- a/man/extract_issue_summary.Rd
+++ b/man/extract_issue_summary.Rd
@@ -12,3 +12,4 @@ extract_issue_summary(txt)
 \description{
 Extract Summary section from Github issue
 }
+\keyword{internal}

--- a/man/extract_issue_tests.Rd
+++ b/man/extract_issue_tests.Rd
@@ -12,3 +12,4 @@ extract_issue_tests(txt)
 \description{
 Extract Tests section from Github issue
 }
+\keyword{internal}

--- a/man/read_test_df.Rd
+++ b/man/read_test_df.Rd
@@ -12,3 +12,4 @@ read_test_df(test_path = ALL_TESTS)
 \description{
 Read in the csv will results from all the tests
 }
+\keyword{internal}

--- a/man/rm_blank.Rd
+++ b/man/rm_blank.Rd
@@ -12,3 +12,4 @@ rm_blank(x)
 \description{
 drop blanks
 }
+\keyword{internal}

--- a/man/rm_h.Rd
+++ b/man/rm_h.Rd
@@ -12,3 +12,4 @@ rm_h(x)
 \description{
 remove leading hyphen
 }
+\keyword{internal}

--- a/man/rm_s.Rd
+++ b/man/rm_s.Rd
@@ -12,3 +12,4 @@ rm_s(x)
 \description{
 remove leading star/bullet
 }
+\keyword{internal}

--- a/man/setup_package_env.Rd
+++ b/man/setup_package_env.Rd
@@ -16,3 +16,4 @@ These are all things that were copied out of internal functions called by testth
 They are necessary because testthat::test_dir does NOT do this, which causes some tests to fail.
 Specifically, this code came mostly from testthat:::test_package_dir and testthat:::test_pkg_env and some from test_check itself.
 }
+\keyword{internal}

--- a/man/sp_sections.Rd
+++ b/man/sp_sections.Rd
@@ -12,3 +12,4 @@ sp_sections(x)
 \description{
 split body by Test and Summary
 }
+\keyword{internal}


### PR DESCRIPTION
Generating the docs for the 0.0.4 release, I noticed a warning message about a bunch of functions missing from the index. This adds the new `read_spec_yaml` function to the index and silences other messages about an internal function.

I should have taken a look before the release, but, this is the only change on top of develop, so I'll regenerate the 0.0.4 docs once this is merged in.