### PR TITLE
deps: move checkmate from Suggests to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ VignetteBuilder: knitr
 RoxygenNote: 7.1.1
 Imports: 
     callr,
+    checkmate,
     devtools,
     dplyr,
     fs,
@@ -49,7 +50,6 @@ Imports:
     tidyr,
     withr (>= 2.3.0)
 Suggests:
-    checkmate,
     digest,
     ghpm (>= 0.5.1),
     googlesheets4,


### PR DESCRIPTION
checkmate is used in `get_sys_info` and `leading_lcs` (reached via
`parse_testthat_list_reporter`) without any guards.  Both are
important mrgvalprep pieces, so make checkmate a hard requirement.