### PR TITLE
BUG: unique requirement IDs

### DIFF
--- a/R/read-spec-yaml.R
+++ b/R/read-spec-yaml.R
@@ -123,7 +123,7 @@ read_spec_yaml <- function(stories, requirements = NULL) {
         requirements,
         ~ read_requirements_yaml(yaml::read_yaml(.x)))) %>%
       check_uniq_col_vals("RequirementId")
-    res <- mrgvalprep:::merge_requirements_and_stories(res, df_reqs)
+    res <- merge_requirements_and_stories(res, df_reqs)
   }
 
   return(res)

--- a/inst/yaml-input/stories-1.yaml
+++ b/inst/yaml-input/stories-1.yaml
@@ -11,5 +11,6 @@ S002:
   description: >
     S002 description
   requirements:
+  - R002
   - R003
   ProductRisk: low

--- a/tests/testthat/test-read-spec-yaml.R
+++ b/tests/testthat/test-read-spec-yaml.R
@@ -22,9 +22,10 @@ test_that("read_spec_yaml() supports requirements", {
                      yaml_file("requirements-2.yaml")))
 
   expect_setequal(names(spec), STORIES_AND_REQS_COLS)
-  expect_equal(nrow(spec), 3)
+  expect_equal(nrow(spec), 4)
   expect_setequal(spec$TestIds,
                   list(c("TEST-ID-001", "TEST-ID-002"),
+                       "TEST-ID-001",
                        "TEST-ID-001",
                        "TEST-ID-003"))
 })
@@ -37,7 +38,7 @@ test_that("read_spec_yaml() aborts on repeated IDs", {
     class = "mrgvalprep_input_error")
 
   # With stories and requirements, it's the requirement ID that can't be
-  # repeated.
+  # repeated with requirements spec
   expect_error(
     read_spec_yaml(
       stories = yaml_file("stories-1.yaml"),


### PR DESCRIPTION
We have a check that story IDs must be unique and another, if requirements are used, that requirement IDs must be unique.

However, we check that the requirement IDs must be unique _after_ we join them against the stories. This should _not_ be enforced, because multiple stories can refer to the same requirement. Instead, we need to check for uniqueness _before_ joining. This is fixed in this PR.

# Reprex of issue

Note that making the change to the test data in d5592a3cfb9dfa72982c3226d30adceb61968c40 causes the old code (prior to d626b928831014782269ab31d5a537758b54b564) to erroneously fail the tests with:
```
Error (test-read-spec-yaml.R:19:3): read_spec_yaml() supports requirements
<mrgvalprep_input_error/rlang_error/error/condition>
Error in `read_spec_yaml(stories = yaml_file("stories-1.yaml"), requirements = c(yaml_file("requirements-1.yaml"), 
    yaml_file("requirements-2.yaml")))`: Duplicate values for RequirementId found:
 - R002
Backtrace:
 1. mrgvalprep::read_spec_yaml(...)
```

With the change in d626b928831014782269ab31d5a537758b54b564 it correctly passes.