### PR TITLE
treewide: don't use .data in tidy selection context

### DIFF
--- a/R/assign-test-ids.R
+++ b/R/assign-test-ids.R
@@ -88,7 +88,7 @@ milestone_to_test_id <- function(stories_df, tests, return_missing_ids=FALSE){
   # Ensure test ids are sorted (necessary for replacement)
   tests <- sort_tests_by_nchar(tests)
 
-  dd <- stories_df %>% rename(TestNames = .data$TestIds)
+  dd <- stories_df %>% rename(TestNames = "TestIds")
 
   merged <- unnest(dd, "TestNames") %>%
     mutate(TestNames = str_trim(.data$TestNames, "both")) %>%
@@ -99,9 +99,9 @@ milestone_to_test_id <- function(stories_df, tests, return_missing_ids=FALSE){
 
   ### Scan for missed cases ###
   missing_ids <- filter(merged, is.na(.data$TestIds)) %>%
-    select(.data$StoryId, .data$StoryName, .data$StoryDescription, .data$TestNames)
+    select("StoryId", "StoryName", "StoryDescription", "TestNames")
   missing_milestones <- filter(merged, is.na(.data$StoryId)) %>%
-    select(.data$TestNames, .data$TestIds, .data$TestFile, .data$new)
+    select("TestNames", "TestIds", "TestFile", "new")
 
   if(nrow(missing_milestones) > 0){
     msg_dat <- data.frame(missing_milestones) # tibble will be truncated
@@ -109,7 +109,7 @@ milestone_to_test_id <- function(stories_df, tests, return_missing_ids=FALSE){
             The corresponding Test Id's have still been added to the test files:\n", print_and_capture(msg_dat),"\n")
   }
   if(nrow(missing_ids) > 0){
-    msg_dat <- missing_ids %>% chop(c(.data$TestNames))
+    msg_dat <- missing_ids %>% chop("TestNames")
     message("\nWarning: The following github issues did not have a matching test.
             Consider modifying the milestone/issue to ensure they are recognized.\n", print_and_capture(as.list(msg_dat)),"\n")
   }
@@ -117,9 +117,9 @@ milestone_to_test_id <- function(stories_df, tests, return_missing_ids=FALSE){
 
   merged <- merged %>% filter(!is.na(.data$StoryId)) %>%
     mutate(TestIds = ifelse(is.na(.data$TestIds), .data$TestNames, .data$TestIds)) %>%
-    select(.data$StoryId, .data$StoryName, .data$StoryDescription, .data$ProductRisk, .data$TestIds) %>%
+    select("StoryId", "StoryName", "StoryDescription", "ProductRisk", "TestIds") %>%
     distinct() %>%
-    chop(c(.data$TestIds))
+    chop("TestIds")
 
   if(return_missing_ids){
     return(
@@ -161,7 +161,7 @@ parse_tests <- function(test_file) {
 sort_tests_by_nchar <- function(test_ids){
   test_ids <- test_ids %>% mutate(nchars=nchar(.data$TestNames))
   test_ids <- test_ids %>% arrange(desc(.data$nchars)) %>%
-    select(-.data$nchars)
+    select(-"nchars")
   return(test_ids)
 }
 

--- a/R/mrgvalprep.R
+++ b/R/mrgvalprep.R
@@ -1,4 +1,4 @@
 #' Pre-processing helpers for ingesting data destined for `mrgvalidate`
-#' @importFrom rlang abort warn inform %||%
+#' @importFrom rlang abort warn inform %||% .data
 #' @name mrgvalprep
 NULL

--- a/R/parse-github-issues.R
+++ b/R/parse-github-issues.R
@@ -6,7 +6,6 @@
 #' See `mrgvalidate::input_formats` for details.
 #' @importFrom tidyr unnest nest
 #' @importFrom dplyr select mutate left_join
-#' @importFrom rlang .data
 #' @importFrom stringr str_pad
 #' @importFrom checkmate assert_string
 #' @param org Github organization that the repo is under.
@@ -49,7 +48,6 @@ parse_github_issues <- function(org, repo, mile, domain = VALID_DOMAINS, prefix)
 #' used to pull the raw content for issues associated with a given milestone.
 #' @importFrom dplyr filter
 #' @inheritParams parse_github_issues
-#' @importFrom rlang .data
 #' @seealso [parse_github_issues()]
 #' @export
 get_issues <- function(org, repo, mile, domain = VALID_DOMAINS) {
@@ -71,7 +69,6 @@ get_issues <- function(org, repo, mile, domain = VALID_DOMAINS) {
 #' @param repo The name of the repo for the package you are validating
 #' @param domain Domain where repo lives. Either "github.com" or "ghe.metrumrg.com", defaulting to "github.com"
 #' @importFrom dplyr filter select mutate
-#' @importFrom rlang .data
 #' @keywords internal
 get_risk <- function(org, repo, domain = VALID_DOMAINS) {
   check_for_ghpm("get_risk()")

--- a/R/parse-github-issues.R
+++ b/R/parse-github-issues.R
@@ -38,7 +38,7 @@ parse_github_issues <- function(org, repo, mile, domain = VALID_DOMAINS, prefix)
       get_risk(org, repo, domain),
       by = "issue"
     ) %>%
-    select(.data$StoryId, .data$StoryName, .data$StoryDescription, .data$ProductRisk, .data$TestIds)
+    select("StoryId", "StoryName", "StoryDescription", "ProductRisk", "TestIds")
 
 }
 
@@ -82,10 +82,10 @@ get_risk <- function(org, repo, domain = VALID_DOMAINS) {
   }
   issue_lab <- ghpm::get_issue_labels(org, repo, ghpm::api_url(hostname = domain))
   issue_lab <- filter(issue_lab, grepl("risk", .data$label, fixed = TRUE))
-  risk <- select(issue_lab, .data$issue, risk = .data$label)
+  risk <- select(issue_lab, "issue", risk = "label")
   risk %>%
     mutate(ProductRisk = sub("risk: ", "", .data$risk, fixed = TRUE)) %>%
-    select(-.data$risk)
+    select(-"risk")
 }
 
 #' @keywords internal

--- a/R/parse-test-output.R
+++ b/R/parse-test-output.R
@@ -13,7 +13,6 @@
 #' @importFrom purrr map_chr map_lgl map_dfr
 #' @importFrom dplyr mutate
 #' @importFrom stringr str_replace fixed
-#' @importFrom rlang .data
 #' @export
 parse_testthat_list_reporter <- function(result, roll_up_ids = FALSE) {
   test_results <- map_dfr(result, function(.r) {
@@ -77,7 +76,6 @@ parse_testthat_list_reporter <- function(result, roll_up_ids = FALSE) {
 #' @importFrom jsonlite fromJSON
 #' @importFrom purrr map_dfr
 #' @importFrom readr read_lines
-#' @importFrom rlang .data
 #' @export
 parse_golang_test_json <- function(test_file, roll_up_ids = TRUE) {
   line_by_line <- read_lines(test_file)

--- a/R/parse-test-output.R
+++ b/R/parse-test-output.R
@@ -39,7 +39,7 @@ parse_testthat_list_reporter <- function(result, roll_up_ids = FALSE) {
     test_results <- roll_up_test_ids(test_results)
   }
 
-  return(select(test_results, .data$TestName, .data$passed, .data$failed, .data$TestId))
+  return(select(test_results, "TestName", "passed", "failed", "TestId"))
 }
 
 
@@ -87,7 +87,7 @@ parse_golang_test_json <- function(test_file, roll_up_ids = TRUE) {
     filter(!is.na(.data$Test)) %>%
     filter(str_detect(.data$Test, "\\/")) %>% # TODO: I think this throws out only the full test function summaries, but should double check
     filter(.data$Action %in% c("pass", "fail", "skip")) %>%
-    rename(TestName = .data$Test) %>%
+    rename(TestName = "Test") %>%
     mutate(
       TestId = parse_test_id(.data$TestName),
       TestName = strip_test_id(.data$TestName, .data$TestId),
@@ -106,7 +106,7 @@ parse_golang_test_json <- function(test_file, roll_up_ids = TRUE) {
     test_results <- roll_up_test_ids(test_results)
   }
 
-  return(select(test_results, .data$TestName, .data$passed, .data$failed, .data$TestId))
+  return(select(test_results, "TestName", "passed", "failed", "TestId"))
 }
 
 
@@ -184,5 +184,5 @@ roll_up_test_ids <- function(test_df) {
 
   test_df %>%
     bind_rows(no_id_tests) %>%
-    select(.data$TestName, .data$passed, .data$failed, .data$TestId)
+    select("TestName", "passed", "failed", "TestId")
 }

--- a/R/read-spec-gsheet.R
+++ b/R/read-spec-gsheet.R
@@ -71,7 +71,7 @@ read_requirements_gsheet <- function
     rename(RequirementId = !!req_id_col,
            RequirementDescription = !!req_description_col,
            TestIds = !!test_ids_col) %>%
-    select(.data$RequirementId, .data$RequirementDescription, .data$TestIds) %>%
+    select("RequirementId", "RequirementDescription", "TestIds") %>%
     mutate(TestIds = stringr::str_split(.data$TestIds, "[\\s,;]+"))
 }
 
@@ -100,8 +100,8 @@ read_stories_gsheet <- function
            StoryDescription = !!story_description_col,
            ProductRisk = !!risk_col,
            RequirementIds = !!req_ids_col) %>%
-    select(.data$StoryId, .data$StoryName, .data$StoryDescription,
-           .data$ProductRisk, .data$RequirementIds) %>%
+    select("StoryId", "StoryName", "StoryDescription",
+           "ProductRisk", "RequirementIds") %>%
     mutate(RequirementIds = stringr::str_split(.data$RequirementIds, "[\\s,;]+"))
 }
 
@@ -123,8 +123,8 @@ read_stories_only_gsheet <- function
            StoryDescription = !!story_description_col,
            ProductRisk = !!risk_col,
            TestIds = !!test_ids_col) %>%
-    select(.data$StoryId, .data$StoryName, .data$StoryDescription,
-           .data$ProductRisk, .data$TestIds) %>%
+    select("StoryId", "StoryName", "StoryDescription",
+           "ProductRisk", "TestIds") %>%
     mutate(TestIds = stringr::str_split(.data$TestIds, "[\\s,;]+"))
 }
 

--- a/R/read-spec-gsheet.R
+++ b/R/read-spec-gsheet.R
@@ -57,7 +57,6 @@ read_spec_gsheets <- function
 #'   in input Google Sheet.
 #' @return Tibble with the above columns.
 #' @importFrom dplyr rename select mutate
-#' @importFrom rlang .data
 #' @keywords internal
 read_requirements_gsheet <- function
 (
@@ -82,7 +81,6 @@ read_requirements_gsheet <- function
 #'   Names of relevant columns in input Google Sheet.
 #' @return Tibble with the above columns.
 #' @importFrom dplyr rename select mutate
-#' @importFrom rlang .data
 #' @keywords internal
 read_stories_gsheet <- function
 (

--- a/R/requirements-from-tests.R
+++ b/R/requirements-from-tests.R
@@ -52,7 +52,7 @@ req_df_from_tests <- function(test_df) {
       req_desc = .data$TestName,
       test_ids = .data$TestId
     ) %>%
-    select(.data$req_id, .data$req_desc, .data$test_ids)
+    select("req_id", "req_desc", "test_ids")
 }
 
 #' @describeIn requirements_from_tests Write requirements YAML file from

--- a/R/stories-to-yaml.R
+++ b/R/stories-to-yaml.R
@@ -43,9 +43,9 @@ stories_to_yaml <- function(
     mutate(TestIds = sapply(.data$TestIds, toString))
   dl <- dd %>%
     rename(
-      name = .data$StoryName,
-      description = .data$StoryDescription,
-      tests = .data$TestIds
+      name = "StoryName",
+      description = "StoryDescription",
+      tests = "TestIds"
     ) %>%
     split(seq(nrow(dd))) %>%
     setNames(dd$StoryId) %>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -105,6 +105,6 @@ sp_sections <- function(x) {
 merge_requirements_and_stories <- function(stories, reqs) {
   stories_flat <- stories %>%
     unnest("RequirementIds") %>%
-    rename(RequirementId = .data$RequirementIds)
+    rename(RequirementId = "RequirementIds")
   return(full_join(stories_flat, reqs, by = "RequirementId"))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,7 +6,6 @@
 #' Read in the csv will results from all the tests
 #' @importFrom readr read_csv cols
 #' @importFrom dplyr rename mutate_at
-#' @importFrom rlang .data
 #' @param test_path File path to file containing test results
 #' @keywords internal
 read_test_df <- function(test_path = ALL_TESTS) {
@@ -100,7 +99,6 @@ sp_sections <- function(x) {
 #'   requirement ID.
 #' @importFrom dplyr full_join
 #' @importFrom tidyr unnest
-#' @importFrom rlang .data
 #' @keywords internal
 merge_requirements_and_stories <- function(stories, reqs) {
   stories_flat <- stories %>%

--- a/R/validate-tests.R
+++ b/R/validate-tests.R
@@ -16,7 +16,6 @@
 #'
 #' @importFrom dplyr group_by summarize bind_rows
 #' @importFrom purrr map_df map map_dfr
-#' @importFrom rlang .data
 #' @importFrom fs dir_exists dir_create
 #'
 #' @return Invisibly returns tibble of formatted test output. Note that this


### PR DESCRIPTION
tidyselect deprecated using .data in the selection context, leading to our tests generating many warnings like this:

    Warning ('test-stories-to-yaml.R:5'): stories_to_yaml() works correctly with google sheet
    Use of .data in tidyselect expressions was deprecated in tidyselect
    1.2.0.
    ℹ Please use `"StoryDescription"` instead of `.data$StoryDescription`

Switch all of these spots over to using the string form.

---

After these changes, the full test suite passes (including `MRGVALIDATE_TEST_GHE`- and `{GHE,GH}_PAT`-guarded tests) when executed under `Rscript -e 'options(warn = 2)' -e 'devtools::test()'`.

More information: https://www.tidyverse.org/blog/2022/10/tidyselect-1-2-0/#using-data-inside-selections